### PR TITLE
Add thumbnails

### DIFF
--- a/stac_planet_api/api.py
+++ b/stac_planet_api/api.py
@@ -210,10 +210,9 @@ async def get_search(
     if sortby:
         search_request["sortby"] = [
             {
-                "field": sort[1:] if sort[0] in ["-", "+"] else sort,
-                "direction": "desc" if sort[0] == "-" else "asc",
+                "field": sortby[1:] if sortby[0] in ["-", "+"] else sortby,
+                "direction": "desc" if sortby[0] == "-" else "asc",
             }
-            for sort in sortby
         ]
 
     if filter:

--- a/stac_planet_api/api.py
+++ b/stac_planet_api/api.py
@@ -210,9 +210,10 @@ async def get_search(
     if sortby:
         search_request["sortby"] = [
             {
-                "field": sortby[1:] if sortby[0] in ["-", "+"] else sortby,
-                "direction": "desc" if sortby[0] == "-" else "asc",
+                "field": sort[1:] if sort[0] in ["-", "+"] else sort,
+                "direction": "desc" if sort[0] == "-" else "asc",
             }
+            for sort in sortby.split(",")
         ]
 
     if filter:

--- a/stac_planet_api/request_adaptor.py
+++ b/stac_planet_api/request_adaptor.py
@@ -93,8 +93,10 @@ def stac_to_planet_request(stac_request: dict) -> tuple[dict, dict]:
         planet_parameters["_page_size"] = limit
 
     if limit := getattr(stac_request, "sortby", None):
+        sort_param = limit[0].__dict__
+
         planet_parameters["_sort"] = (
-            f"{limit.get('field')} {limit.get('direction', 'asc')}"
+            f"{sort_param.get('field')} {sort_param.get('direction', 'asc').value}"
         )
 
     return planet_parameters, planet_request

--- a/stac_planet_api/response_adaptor.py
+++ b/stac_planet_api/response_adaptor.py
@@ -78,11 +78,13 @@ def get_search_links(base_url: str, next_token: str, prev_token: str) -> list:
     return links
 
 
-def get_assets(thumbnail_href: str, assets_href: str, auth) -> dict:
+def get_assets(thumbnail_href: str, assets_href: str, auth, path:str=None) -> dict:
     """
     Get item assets
     """
-    output = {"thumbnail": {"href": thumbnail_href, "roles": ["thumbnail"]}}
+    output = {
+        "external_thumbnail": {"href": thumbnail_href}
+    }
 
     client = httpx.Client(
         auth=auth,
@@ -94,6 +96,14 @@ def get_assets(thumbnail_href: str, assets_href: str, auth) -> dict:
 
     for key, value in assets.items():
         output[key] = {"href": value["_links"]["_self"], "roles": ["data"]}
+
+    if path:
+        output['thumbnail'] = {
+            "href": f"{path}/thumbnail",
+            "roles": ["thumbnail"],
+            "size": 87826,
+            "location": "on_disk"
+        }
 
     return output
 
@@ -176,7 +186,7 @@ def get_bbox(coordinate_type: str, coordinates: list) -> list:
     return None
 
 
-def map_item(planet_item, base_url, auth):
+def map_item(planet_item, base_url, auth, path=None):
 
     return {
         "type": "Feature",
@@ -200,6 +210,7 @@ def map_item(planet_item, base_url, auth):
             thumbnail_href=planet_item["_links"]["thumbnail"],
             assets_href=planet_item["_links"]["assets"],
             auth=auth,
+            path=path
         ),
     }
 


### PR DESCRIPTION
Thumbnails require an API key so following the link provided by Planet won't work unless the user is logged in. Moved the thumbnail asset to `external_thumbnail` and created a new thumbnail asset which can be accessed via EODHP