### PR TITLE
Set minimum release age to 7 days

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ build-backend = "hatchling.build"
 
 [tool.uv]
 package = true
+exclude-newer = "7 days"
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = "==3.13.*"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
Adds `exclude-newer = "7 days"` under `[tool.uv]` so uv only resolves packages published at least 7 days ago (same as EO-DataHub/harvest-transformer#60, EO-DataHub/planet-harvester#21). uv.lock regenerated — no version changes, only the new resolver option recorded.